### PR TITLE
Fix : Issue #01

### DIFF
--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -221,9 +221,6 @@ private class BottomSheetDialogWrapper(
                 }
 
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
-                    if (newState == STATE_HIDDEN) {
-                        onDismissRequest()
-                    }
                 }
             }
         )


### PR DESCRIPTION
Resolve issues where onDismissRequest is called twice when bottom sheet is dismissed by swiping down

![bottomsheetdialog-compose_issue](https://user-images.githubusercontent.com/74607521/185809874-8202dba3-4c1d-4555-ac65-58bdc511c938.png)
onDismissRequest is called twice when bottom sheet is dismissed by swiping down.

[Issue resolution] Modified to be called once.
BottomSheet onStateChanged STATE_HIDDEN already has a hidden bottom sheet.
Cleared onDismissRequest in onStateChanged function.

Thank you for reading it.



