### PR TITLE
Add NavigationBarProperties to customize navigationBar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation Dependencies.composeActivity
     implementation Dependencies.androidxCoreKtx
     implementation Dependencies.material
+    implementation Dependencies.colorPicker
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/BooleanPreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/BooleanPreference.kt
@@ -1,0 +1,40 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BooleanPreference(
+    value: Boolean,
+    onValueChange: (Boolean) -> Unit,
+    label: String,
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp, 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body1,
+            fontWeight = FontWeight.Bold
+        )
+        Switch(
+            checked = value,
+            onCheckedChange = currentOnValueChange
+        )
+    }
+}

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/ColorPreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/ColorPreference.kt
@@ -1,0 +1,124 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.github.skydoves.colorpicker.compose.*
+
+@Composable
+fun ColorPreference(
+    value: Color,
+    onValueChange: (Color) -> Unit,
+    label: String
+) {
+    val surfaceColor = MaterialTheme.colors.surface
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    var showColorPickerDialog by rememberSaveable {
+        mutableStateOf(false)
+    }
+    if (showColorPickerDialog) {
+        var targetColor by remember {
+            mutableStateOf(value)
+        }
+        Dialog(
+            onDismissRequest = { showColorPickerDialog = false }
+        ) {
+            Surface {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp, 8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    val controller = rememberColorPickerController()
+                    HsvColorPicker(
+                        modifier = Modifier
+                            .size(300.dp),
+                        controller = controller,
+                        onColorChanged = { colorEnvelope: ColorEnvelope ->
+                            targetColor = colorEnvelope.color
+                        }
+                    )
+                    AlphaSlider(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(10.dp)
+                            .height(35.dp),
+                        controller = controller,
+                    )
+                    BrightnessSlider(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(10.dp)
+                            .height(35.dp),
+                        controller = controller,
+                    )
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(color = targetColor)
+                            .size(64.dp)
+                    )
+                    Text(text = "#" + Integer.toHexString(targetColor.toArgb()).uppercase(),)
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            onValueChange(targetColor)
+                            showColorPickerDialog = false
+                        }
+                    ) {
+                        Text(text = "Apply")
+                    }
+                }
+            }
+        }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp, 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(text = label, fontWeight = FontWeight.Bold)
+        when (value) {
+            MaterialTheme.colors.surface -> {
+                Text("Default - MaterialTheme.colors.surface")
+                Spacer(modifier = Modifier.weight(1F))
+                Button(
+                    onClick = { showColorPickerDialog = true }
+                ) {
+                    Text("Set")
+                }
+            }
+            else -> {
+                Box(
+                    modifier = Modifier
+                        .background(value)
+                        .size(24.dp)
+                )
+                Text(text = "#" + Integer.toHexString(value.toArgb()).uppercase())
+                Button(
+                    onClick = { currentOnValueChange(surfaceColor) }
+                ) {
+                    Text(text = "Reset")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/PreferenceCategory.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/PreferenceCategory.kt
@@ -1,0 +1,22 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PreferenceCategory(
+    label: String
+) {
+    Text(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        text = label,
+        style = MaterialTheme.typography.h6,
+        fontWeight = FontWeight.ExtraBold
+    )
+}

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/SingleChoicePreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/SingleChoicePreference.kt
@@ -1,0 +1,51 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SingleChoicePreference(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    options: List<Pair<String, String>>,
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp, 8.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body1,
+            fontWeight = FontWeight.Bold
+        )
+        options.forEach { (option, description) ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = option == value,
+                    onClick = { currentOnValueChange(option) })
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.body2
+                )
+            }
+        }
+    }
+}

--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -1,13 +1,15 @@
 package com.holix.android.bottomsheetdialog.compose
 
-import android.app.Dialog
 import android.content.Context
 import android.graphics.Outline
+import android.os.Build
 import android.view.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.*
@@ -16,14 +18,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.SecureFlagPolicy
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.ViewTreeViewModelStoreOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -48,8 +48,22 @@ class BottomSheetDialogProperties constructor(
     val dismissOnClickOutside: Boolean = true,
     val dismissWithAnimation: Boolean = false,
     val securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
-    val navigationBarColor: Color = Color.Unspecified
+    val navigationBarProperties: NavigationBarProperties = NavigationBarProperties()
 ) {
+
+    constructor(
+        dismissOnBackPress: Boolean = true,
+        dismissOnClickOutside: Boolean = true,
+        dismissWithAnimation: Boolean = false,
+        securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
+        navigationBarColor: Color
+    ) : this(
+        dismissOnBackPress,
+        dismissOnClickOutside,
+        dismissWithAnimation,
+        securePolicy,
+        NavigationBarProperties(color = navigationBarColor)
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -59,7 +73,7 @@ class BottomSheetDialogProperties constructor(
         if (dismissOnClickOutside != other.dismissOnClickOutside) return false
         if (dismissWithAnimation != other.dismissWithAnimation) return false
         if (securePolicy != other.securePolicy) return false
-        if (navigationBarColor != other.navigationBarColor) return false
+        if (navigationBarProperties != other.navigationBarProperties) return false
 
         return true
     }
@@ -69,9 +83,58 @@ class BottomSheetDialogProperties constructor(
         result = 31 * result + dismissOnClickOutside.hashCode()
         result = 31 * result + dismissWithAnimation.hashCode()
         result = 31 * result + securePolicy.hashCode()
-        result = 31 * result + navigationBarColor.hashCode()
+        result = 31 * result + navigationBarProperties.hashCode()
         return result
     }
+}
+
+/**
+ * Properties used to customize navigationBar.
+
+ * @param color The **desired** [Color] to set. This may require modification if running on an
+ * API level that only supports white navigation bar icons. Additionally this will be ignored
+ * and [Color.Transparent] will be used on API 29+ where gesture navigation is preferred or the
+ * system UI automatically applies background protection in other navigation modes.
+ * @param darkIcons Whether dark navigation bar icons would be preferable.
+ * @param navigationBarContrastEnforced Whether the system should ensure that the navigation
+ * bar has enough contrast when a fully transparent background is requested. Only supported on
+ * API 29+.
+ * @param transformColorForLightContent A lambda which will be invoked to transform [color] if
+ * dark icons were requested but are not available. Defaults to applying a black scrim.
+ *
+ * Inspired by [Accompanist SystemUiController](https://github.com/google/accompanist/blob/main/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt)
+ */
+
+@Immutable
+class NavigationBarProperties(
+    val color: Color = Color.Unspecified,
+    val darkIcons: Boolean = color.luminance() > 0.5f,
+    val navigationBarContrastEnforced: Boolean = true,
+    val transformColorForLightContent: (Color) -> Color = BlackScrimmed
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NavigationBarProperties) return false
+
+        if (color != other.color) return false
+        if (darkIcons != other.darkIcons) return false
+        if (navigationBarContrastEnforced != other.navigationBarContrastEnforced) return false
+        if (transformColorForLightContent != other.transformColorForLightContent) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = color.hashCode()
+        result = 31 * result + darkIcons.hashCode()
+        result = 31 * result + navigationBarContrastEnforced.hashCode()
+        return result
+    }
+}
+
+private val BlackScrim = Color(0f, 0f, 0f, 0.3f) // 30% opaque black
+private val BlackScrimmed: (Color) -> Color = { original ->
+    BlackScrim.compositeOver(original)
 }
 
 /**
@@ -204,6 +267,23 @@ private class BottomSheetDialogWrapper(
 
     override val subCompositionView: AbstractComposeView get() = bottomSheetDialogLayout
 
+    // to control insets
+    private val windowInsetsController = window?.let {
+        WindowCompat.getInsetsController(it, it.decorView)
+    }
+    private var navigationBarDarkContentEnabled: Boolean
+        get() = windowInsetsController?.isAppearanceLightNavigationBars == true
+        set(value) {
+            windowInsetsController?.isAppearanceLightNavigationBars = value
+        }
+
+    private var isNavigationBarContrastEnforced: Boolean
+        get() = Build.VERSION.SDK_INT >= 29 && window?.isNavigationBarContrastEnforced == true
+        set(value) {
+            if (Build.VERSION.SDK_INT >= 29) {
+                window?.isNavigationBarContrastEnforced = value
+            }
+        }
 
     init {
         val window = window ?: error("Dialog has no window")
@@ -283,9 +363,20 @@ private class BottomSheetDialogWrapper(
         )
     }
 
-    private fun setNavigationBarColor(color: Color) {
-        if (color != Color.Unspecified) {
-            window!!.navigationBarColor = color.toArgb()
+    private fun setNavigationBarProperties(properties: NavigationBarProperties) {
+        with(properties) {
+            navigationBarDarkContentEnabled = darkIcons
+            isNavigationBarContrastEnforced = navigationBarContrastEnforced
+
+            window?.navigationBarColor = when {
+                darkIcons && windowInsetsController?.isAppearanceLightNavigationBars != true -> {
+                    // If we're set to use dark icons, but our windowInsetsController call didn't
+                    // succeed (usually due to API level), we instead transform the color to maintain
+                    // contrast
+                    transformColorForLightContent(color)
+                }
+                else -> color
+            }.toArgb()
         }
     }
 
@@ -308,7 +399,7 @@ private class BottomSheetDialogWrapper(
         setSecurePolicy(properties.securePolicy)
         setLayoutDirection(layoutDirection)
         setCanceledOnTouchOutside(properties.dismissOnClickOutside)
-        setNavigationBarColor(properties.navigationBarColor)
+        setNavigationBarProperties(properties.navigationBarProperties)
         dismissWithAnimation = properties.dismissWithAnimation
     }
 

--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -1,5 +1,6 @@
 package com.holix.android.bottomsheetdialog.compose
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Outline
 import android.os.Build
@@ -51,6 +52,7 @@ class BottomSheetDialogProperties constructor(
     val navigationBarProperties: NavigationBarProperties = NavigationBarProperties()
 ) {
 
+    @Deprecated("Use NavigationBarProperties(color = navigationBarColor) instead")
     constructor(
         dismissOnBackPress: Boolean = true,
         dismissOnClickOutside: Boolean = true,
@@ -417,6 +419,8 @@ private class BottomSheetDialogWrapper(
         }
     }
 
+    @Deprecated("Deprecated")
+    @SuppressLint("MissingSuperCall")
     override fun onBackPressed() {
         if (properties.dismissOnBackPress) {
             cancel()

--- a/buildSrc/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/Configuration.kt
@@ -2,7 +2,7 @@ package com.holix.android.bottomsheetdialog.compose
 
 object Configuration {
     const val compileSdk = 33
-    const val targetSdk = 32
+    const val targetSdk = 33
     const val minSdk = 21
     const val majorVersion = 1
     const val minorVersion = 0

--- a/buildSrc/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/Versions.kt
@@ -11,6 +11,8 @@ object Versions {
     internal const val COMPOSE = "1.2.1"
     const val COMPOSE_COMPILER = "1.3.1"
     internal const val COMPOSE_ACTIVITY = "1.5.1"
+
+    internal const val COLOR_PICKER = "1.0.0"
 }
 
 object Dependencies {
@@ -29,4 +31,6 @@ object Dependencies {
     const val composeFoundation = "androidx.compose.foundation:foundation:${Versions.COMPOSE}"
     const val composeTooling = "androidx.compose.ui:ui-tooling:${Versions.COMPOSE}"
     const val composeActivity = "androidx.activity:activity-compose:${Versions.COMPOSE_ACTIVITY}"
+
+    const val colorPicker = "com.github.skydoves:colorpicker-compose:${Versions.COLOR_PICKER}"
 }


### PR DESCRIPTION
## Introduce New Feature : NavigationBarProperties
I need to set icon and background color in navigation bar manually because BottomSheetDialog has a separate window.  [Accompanist SystemUiController](https://github.com/google/accompanist/blob/main/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt) is helpful to solve this problem

<img width="720" alt="image" src="https://user-images.githubusercontent.com/7759511/198013152-ce94debe-e4f4-4e2d-b4d2-13031f5fe6ba.png">

## Improve sample
- set NavigationBarProperties directly in sample to test (Using awesome library 👉🎨colorpicker-compose )
- minor design fixes
<img width="725" alt="image" src="https://user-images.githubusercontent.com/7759511/198011581-2c88695c-ccc0-48aa-bae4-35ca3294ffe0.png">
