### PR TITLE
Introduce BottomSheetBehaviorProperties

### DIFF
--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/MainActivity.kt
@@ -13,18 +13,15 @@ import androidx.compose.material.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
+import com.holix.android.bottomsheetdialog.compose.BottomSheetBehaviorProperties
 import com.holix.android.bottomsheetdialog.compose.BottomSheetDialog
 import com.holix.android.bottomsheetdialog.compose.BottomSheetDialogProperties
 import com.holix.android.bottomsheetdialog.compose.NavigationBarProperties
-import com.holix.android.bottomsheetdialogcomposedemo.preferences.BooleanPreference
-import com.holix.android.bottomsheetdialogcomposedemo.preferences.ColorPreference
-import com.holix.android.bottomsheetdialogcomposedemo.preferences.PreferenceCategory
-import com.holix.android.bottomsheetdialogcomposedemo.preferences.SingleChoicePreference
+import com.holix.android.bottomsheetdialogcomposedemo.preferences.*
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,17 +34,17 @@ class MainActivity : AppCompatActivity() {
                     lightColors()
                 }
             ) {
-                var showBottomSheetDialog by rememberSaveable {
+                var showBottomSheetDialog by remember {
                     mutableStateOf(false)
                 }
                 // BottomSheetProperties
-                var dismissOnBackPress by rememberSaveable {
+                var dismissOnBackPress by remember {
                     mutableStateOf(true)
                 }
-                var dismissOnClickOutside by rememberSaveable {
+                var dismissOnClickOutside by remember {
                     mutableStateOf(true)
                 }
-                var dismissWithAnimation by rememberSaveable {
+                var dismissWithAnimation by remember {
                     mutableStateOf(false)
                 }
                 // NavigationBarProperties
@@ -55,11 +52,45 @@ class MainActivity : AppCompatActivity() {
                 var navigationBarColor by remember(surfaceColor) {
                     mutableStateOf(surfaceColor)
                 }
-                var darkIcons by rememberSaveable {
+                var darkIcons by remember {
                     mutableStateOf(DarkIconsValue.Default)
                 }
-                var navigationBarContrastEnforced by rememberSaveable {
+                var navigationBarContrastEnforced by remember {
                     mutableStateOf(true)
+                }
+                // BottomSheetBehaviorProperties
+                var state by remember {
+                    mutableStateOf(BottomSheetBehaviorProperties.State.Collapsed)
+                }
+                var maxWidth by remember {
+                    mutableStateOf(BottomSheetBehaviorProperties.Size.NotSet)
+                }
+                var maxHeight by remember {
+                    mutableStateOf(BottomSheetBehaviorProperties.Size.NotSet)
+                }
+                var isDraggable by remember {
+                    mutableStateOf(true)
+                }
+                var expandedOffset by remember {
+                    mutableStateOf(0)
+                }
+                var halfExpandedRatio by remember {
+                    mutableStateOf(0.5F)
+                }
+                var isHideable by remember {
+                    mutableStateOf(true)
+                }
+                var peekHeight by remember {
+                    mutableStateOf(BottomSheetBehaviorProperties.PeekHeight.Auto)
+                }
+                var isFitToContents by remember {
+                    mutableStateOf(true)
+                }
+                var skipCollapsed by remember {
+                    mutableStateOf(false)
+                }
+                var isGestureInsetBottomIgnored by remember {
+                    mutableStateOf(false)
                 }
                 if (showBottomSheetDialog) {
                     BottomSheetDialog(
@@ -79,6 +110,19 @@ class MainActivity : AppCompatActivity() {
                                     DarkIconsValue.False -> false
                                 },
                                 navigationBarContrastEnforced = navigationBarContrastEnforced
+                            ),
+                            behaviorProperties = BottomSheetBehaviorProperties(
+                                state = state,
+                                maxWidth = maxWidth,
+                                maxHeight = maxHeight,
+                                isDraggable = isDraggable,
+                                expandedOffset = expandedOffset,
+                                halfExpandedRatio = halfExpandedRatio,
+                                isHideable = isHideable,
+                                peekHeight = peekHeight,
+                                isFitToContents = isFitToContents,
+                                skipCollapsed = skipCollapsed,
+                                isGestureInsetBottomIgnored = isGestureInsetBottomIgnored
                             )
                         )
                     ) {
@@ -93,7 +137,7 @@ class MainActivity : AppCompatActivity() {
                                 verticalArrangement = Arrangement.spacedBy(16.dp)
                             ) {
                                 Text(text = "Title", style = MaterialTheme.typography.h5)
-                                repeat(5) { index ->
+                                repeat(30) { index ->
                                     Text(
                                         text = "Item $index",
                                         style = MaterialTheme.typography.body1
@@ -154,8 +198,7 @@ class MainActivity : AppCompatActivity() {
                                         value.name,
                                         when (value) {
                                             DarkIconsValue.Default ->
-                                                "Default (color.luminance() > 0.5F) = " +
-                                                        "${navigationBarColor.luminance() > 0.5F}"
+                                                "Default (color.luminance() > 0.5F)"
                                             else -> value.name
                                         }
                                     )
@@ -167,6 +210,134 @@ class MainActivity : AppCompatActivity() {
                                     navigationBarContrastEnforced = it
                                 },
                                 label = "navigationBarContrastEnforced"
+                            )
+                            PreferenceCategory("BottomSheetBehaviorProperties")
+                            SingleChoicePreference(
+                                value = state.name,
+                                onValueChange = {
+                                    state = BottomSheetBehaviorProperties.State.valueOf(it)
+                                },
+                                label = "state",
+                                options = BottomSheetBehaviorProperties.State.values().map { value ->
+                                    Pair(value.name, value.name)
+                                }
+                            )
+                            IntPreference(
+                                value = maxWidth.value,
+                                onValueChange = {
+                                    maxWidth = BottomSheetBehaviorProperties.Size(it)
+                                },
+                                label = "maxWidth (px)",
+                                helpText = "Default: not set (-1)",
+                                description = { maxWidth ->
+                                    if (maxWidth == -1) {
+                                        "not set (-1)"
+                                    } else {
+                                        "${maxWidth}px"
+                                    }
+                                },
+                                validate = { maxWidth -> maxWidth == -1 || maxWidth > 0 }
+                            )
+                            IntPreference(
+                                value = maxHeight.value,
+                                onValueChange = {
+                                    maxHeight = BottomSheetBehaviorProperties.Size(it)
+                                },
+                                label = "maxHeight (px)",
+                                helpText = "Default: not set (-1)",
+                                description = { maxHeight ->
+                                    if (maxHeight == -1) {
+                                        "not set (-1)"
+                                    } else {
+                                        "${maxHeight}px"
+                                    }
+                                },
+                                validate = { maxHeight -> maxHeight == -1 || maxHeight > 0 }
+                            )
+                            BooleanPreference(
+                                value = isDraggable,
+                                onValueChange = {
+                                    isDraggable = it
+                                },
+                                label = "isDraggable"
+                            )
+                            IntPreference(
+                                value = expandedOffset,
+                                onValueChange = {
+                                    expandedOffset = it
+                                },
+                                label = "expandedOffset (px)",
+                                helpText = "expandedOffset >= 0",
+                                description = { expandedOffset ->
+                                    if (expandedOffset == 0) {
+                                        "Default (0)"
+                                    } else {
+                                        "${expandedOffset}px"
+                                    }
+                                },
+                                validate = { expandedOffset -> expandedOffset >= 0 }
+                            )
+                            FloatPreference(
+                                value = halfExpandedRatio,
+                                onValueChange = {
+                                    halfExpandedRatio = it
+                                },
+                                label = "halfExpandedRatio",
+                                helpText = "0 < halfExpandedRatio < 1",
+                                description = { halfExpandedRatio ->
+                                    if (halfExpandedRatio == 0.5F) {
+                                        "Default (0.5)"
+                                    } else {
+                                        "$halfExpandedRatio"
+                                    }
+                                },
+                                validate = { halfExpandedRatio ->
+                                    0 < halfExpandedRatio && halfExpandedRatio < 1
+                                }
+                            )
+                            BooleanPreference(
+                                value = isHideable,
+                                onValueChange = {
+                                    isHideable = it
+                                },
+                                label = "isHideable"
+                            )
+                            IntPreference(
+                                value = peekHeight.value,
+                                onValueChange = {
+                                    peekHeight = BottomSheetBehaviorProperties.PeekHeight(it)
+                                },
+                                label = "peekHeight (px)",
+                                helpText = "peekHeight > 0",
+                                description = { peekHeight ->
+                                    if (peekHeight == -1) {
+                                        "Auto (-1)"
+                                    } else {
+                                        "${peekHeight}px"
+                                    }
+                                },
+                                validate = { peekHeight -> peekHeight == -1 || peekHeight > 0 }
+                            )
+                            BooleanPreference(
+                                value = isFitToContents,
+                                onValueChange = {
+                                    isFitToContents = it
+                                },
+                                label = "isFitToContents"
+                            )
+                            BooleanPreference(
+                                value = skipCollapsed,
+                                onValueChange = {
+                                    skipCollapsed = it
+                                },
+                                label = "skipCollapsed"
+                            )
+                            BooleanPreference(
+                                value = isGestureInsetBottomIgnored,
+                                onValueChange = {
+                                    isGestureInsetBottomIgnored = it
+                                },
+                                label = "isGestureInsetBottomIgnored"
                             )
                         }
                         Button(

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/ColorPreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/ColorPreference.kt
@@ -1,6 +1,7 @@
 package com.holix.android.bottomsheetdialogcomposedemo.preferences
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
@@ -8,7 +9,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -16,8 +16,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import com.github.skydoves.colorpicker.compose.*
+import com.holix.android.bottomsheetdialog.compose.BottomSheetBehaviorProperties
+import com.holix.android.bottomsheetdialog.compose.BottomSheetDialog
+import com.holix.android.bottomsheetdialog.compose.BottomSheetDialogProperties
 
 @Composable
 fun ColorPreference(
@@ -27,15 +29,21 @@ fun ColorPreference(
 ) {
     val surfaceColor = MaterialTheme.colors.surface
     val currentOnValueChange by rememberUpdatedState(onValueChange)
-    var showColorPickerDialog by rememberSaveable {
+    var showColorPickerDialog by remember {
         mutableStateOf(false)
     }
     if (showColorPickerDialog) {
         var targetColor by remember {
             mutableStateOf(value)
         }
-        Dialog(
-            onDismissRequest = { showColorPickerDialog = false }
+        BottomSheetDialog(
+            onDismissRequest = { showColorPickerDialog = false },
+            properties = BottomSheetDialogProperties(
+                behaviorProperties = BottomSheetBehaviorProperties(
+                    state = BottomSheetBehaviorProperties.State.Expanded,
+                    skipCollapsed = true
+                )
+            )
         ) {
             Surface {
                 Column(
@@ -91,7 +99,8 @@ fun ColorPreference(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp, 8.dp),
+            .clickable { showColorPickerDialog = true }
+            .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
@@ -99,12 +108,6 @@ fun ColorPreference(
         when (value) {
             MaterialTheme.colors.surface -> {
                 Text("Default - MaterialTheme.colors.surface")
-                Spacer(modifier = Modifier.weight(1F))
-                Button(
-                    onClick = { showColorPickerDialog = true }
-                ) {
-                    Text("Set")
-                }
             }
             else -> {
                 Box(

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/FloatPreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/FloatPreference.kt
@@ -1,0 +1,86 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun FloatPreference(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    label: String,
+    helpText: String,
+    description: (Float) -> String = { "$it" },
+    validate: (Float) -> Boolean = { true },
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    var _value by remember(value) {
+        mutableStateOf("$value")
+    }
+    var showDialog by remember {
+        mutableStateOf(false)
+    }
+    if (showDialog) {
+        Dialog(
+            onDismissRequest = { showDialog = false }
+        ) {
+            Surface(
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = _value,
+                        onValueChange = { _value = it },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Decimal
+                        ),
+                        placeholder = {
+                            Text(text = helpText)
+                        },
+                        isError = !validate(_value.toFloatOrNull() ?: 0F),
+                    )
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = validate(_value.toFloatOrNull() ?: 0F),
+                        onClick = {
+                            _value.toFloatOrNull()?.let {
+                                currentOnValueChange(it)
+                            }
+                            showDialog = false
+                        }
+                    ) {
+                        Text(text = "Set")
+                    }
+                }
+            }
+        }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDialog = true }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body1,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            modifier = Modifier.weight(1F),
+            text = description(value)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/IntPreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/IntPreference.kt
@@ -1,0 +1,86 @@
+package com.holix.android.bottomsheetdialogcomposedemo.preferences
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun IntPreference(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    label: String,
+    helpText: String,
+    description: (Int) -> String = { "$it" },
+    validate: (Int) -> Boolean = { true },
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    var _value by remember(value) {
+        mutableStateOf("$value")
+    }
+    var showDialog by remember {
+        mutableStateOf(false)
+    }
+    if (showDialog) {
+        Dialog(
+            onDismissRequest = { showDialog = false }
+        ) {
+            Surface(
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = _value,
+                        onValueChange = { _value = it },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number
+                        ),
+                        placeholder = {
+                            Text(text = helpText)
+                        },
+                        isError = !validate(_value.toIntOrNull() ?: 0),
+                    )
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = validate(_value.toIntOrNull() ?: 0),
+                        onClick = {
+                            _value.toIntOrNull()?.let {
+                                currentOnValueChange(it)
+                            }
+                            showDialog = false
+                        }
+                    ) {
+                        Text(text = "Set")
+                    }
+                }
+            }
+        }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDialog = true }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body1,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            modifier = Modifier.weight(1F),
+            text = description(value)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/SingleChoicePreference.kt
+++ b/app/src/main/kotlin/com/holix/android/bottomsheetdialogcomposedemo/preferences/SingleChoicePreference.kt
@@ -1,19 +1,18 @@
 package com.holix.android.bottomsheetdialogcomposedemo.preferences
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.RadioButton
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 
 @Composable
 fun SingleChoicePreference(
@@ -23,29 +22,62 @@ fun SingleChoicePreference(
     options: List<Pair<String, String>>,
 ) {
     val currentOnValueChange by rememberUpdatedState(onValueChange)
-    Column(
+    var showChoiceDialog by remember {
+        mutableStateOf(false)
+    }
+    if (showChoiceDialog) {
+        Dialog(
+            onDismissRequest = { showChoiceDialog = false }
+        ) {
+            Surface(
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Column {
+                    options.forEach { (option, description) ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    currentOnValueChange(option)
+                                    showChoiceDialog = false
+                                }
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = description,
+                                color = if (option == value) {
+                                    MaterialTheme.colors.primary
+                                } else {
+                                    Color.Unspecified
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp, 8.dp)
+            .clickable { showChoiceDialog = true }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.body1,
             fontWeight = FontWeight.Bold
         )
-        options.forEach { (option, description) ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                RadioButton(
-                    selected = option == value,
-                    onClick = { currentOnValueChange(option) })
+        options
+            .firstOrNull { (option, _) -> option == value }
+            ?.let { (_, description) ->
+                Spacer(modifier = Modifier.width(16.dp))
                 Text(
-                    text = description,
-                    style = MaterialTheme.typography.body2
+                    modifier = Modifier.weight(1F),
+                    text = description
                 )
             }
-        }
     }
 }

--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.graphics.Outline
 import android.os.Build
 import android.view.*
+import androidx.annotation.FloatRange
+import androidx.annotation.IntRange
+import androidx.annotation.Px
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
@@ -25,14 +28,13 @@ import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.ViewTreeViewModelStoreOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
-import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
+import com.google.android.material.bottomsheet.BottomSheetBehavior.*
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import java.util.*
 
 
 /**
- * Properties used to customize the behavior of a [BottomSheetDialog].
+ * Properties used to customize [BottomSheetDialog].
  *
  * @property dismissOnBackPress whether the dialog can be dismissed by pressing the back button.
  * If true, pressing the back button will call onDismissRequest.
@@ -49,7 +51,8 @@ class BottomSheetDialogProperties constructor(
     val dismissOnClickOutside: Boolean = true,
     val dismissWithAnimation: Boolean = false,
     val securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
-    val navigationBarProperties: NavigationBarProperties = NavigationBarProperties()
+    val navigationBarProperties: NavigationBarProperties = NavigationBarProperties(),
+    val behaviorProperties: BottomSheetBehaviorProperties = BottomSheetBehaviorProperties()
 ) {
 
     @Deprecated("Use NavigationBarProperties(color = navigationBarColor) instead")
@@ -76,6 +79,7 @@ class BottomSheetDialogProperties constructor(
         if (dismissWithAnimation != other.dismissWithAnimation) return false
         if (securePolicy != other.securePolicy) return false
         if (navigationBarProperties != other.navigationBarProperties) return false
+        if (behaviorProperties != other.behaviorProperties) return false
 
         return true
     }
@@ -86,7 +90,96 @@ class BottomSheetDialogProperties constructor(
         result = 31 * result + dismissWithAnimation.hashCode()
         result = 31 * result + securePolicy.hashCode()
         result = 31 * result + navigationBarProperties.hashCode()
+        result = 31 * result + behaviorProperties.hashCode()
         return result
+    }
+}
+
+/**
+ * Properties used to set [com.google.android.material.bottomsheet.BottomSheetBehavior].
+ *
+ * @see [com.google.android.material.bottomsheet.BottomSheetBehavior]
+ */
+@Immutable
+class BottomSheetBehaviorProperties(
+    val state: BottomSheetDialogState = BottomSheetDialogState.Collapsed,
+    val maxWidth: Size = Size.NotSet,
+    val maxHeight: Size = Size.NotSet,
+    val isDraggable: Boolean = true,
+    @IntRange(from = 0)
+    val expandedOffset: Int = 0,
+    @FloatRange(from = 0.0, to = 1.0, fromInclusive = false, toInclusive = false)
+    val halfExpandedRatio: Float = 0.5F,
+    val isHideable: Boolean = true,
+    val peekHeight: PeekHeight = PeekHeight.Auto,
+    val isFitToContents: Boolean = true,
+    val skipCollapsed: Boolean = false,
+    val isGestureInsetBottomIgnored: Boolean = false
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BottomSheetBehaviorProperties) return false
+
+        if (state != other.state) return false
+        if (maxWidth != other.maxWidth) return false
+        if (maxHeight != other.maxHeight) return false
+        if (isDraggable != other.isDraggable) return false
+        if (expandedOffset != other.expandedOffset) return false
+        if (halfExpandedRatio != other.halfExpandedRatio) return false
+        if (isHideable != other.isHideable) return false
+        if (peekHeight != other.peekHeight) return false
+        if (isFitToContents != other.isFitToContents) return false
+        if (skipCollapsed != other.skipCollapsed) return false
+        if (isGestureInsetBottomIgnored != other.isGestureInsetBottomIgnored) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + maxWidth.hashCode()
+        result = 31 * result + maxHeight.hashCode()
+        result = 31 * result + isDraggable.hashCode()
+        result = 31 * result + expandedOffset.hashCode()
+        result = 31 * result + halfExpandedRatio.hashCode()
+        result = 31 * result + isHideable.hashCode()
+        result = 31 * result + peekHeight.hashCode()
+        result = 31 * result + isFitToContents.hashCode()
+        result = 31 * result + skipCollapsed.hashCode()
+        result = 31 * result + isGestureInsetBottomIgnored.hashCode()
+        return result
+    }
+
+    @Immutable
+    enum class BottomSheetDialogState {
+        @Stable
+        Expanded,
+        @Stable
+        HalfExpanded,
+        @Stable
+        Collapsed,
+        @Stable
+        Hidden
+    }
+
+    @JvmInline
+    @Immutable
+    value class Size(@Px val value: Int) {
+
+        companion object {
+            @Stable
+            val NotSet = Size(-1)
+        }
+    }
+
+    @JvmInline
+    @Stable
+    value class PeekHeight(val value: Int) {
+
+        companion object {
+            @Stable
+            val Auto = PeekHeight(PEEK_HEIGHT_AUTO)
+        }
     }
 }
 
@@ -391,6 +484,25 @@ private class BottomSheetDialogWrapper(
         }
     }
 
+    private fun setBehaviorProperties(behaviorProperties: BottomSheetBehaviorProperties) {
+        this.behavior.state = when (behaviorProperties.state) {
+            BottomSheetBehaviorProperties.BottomSheetDialogState.Expanded -> STATE_EXPANDED
+            BottomSheetBehaviorProperties.BottomSheetDialogState.Collapsed -> STATE_COLLAPSED
+            BottomSheetBehaviorProperties.BottomSheetDialogState.HalfExpanded -> STATE_HALF_EXPANDED
+            BottomSheetBehaviorProperties.BottomSheetDialogState.Hidden -> STATE_HIDDEN
+        }
+        this.behavior.maxWidth = behaviorProperties.maxWidth.value
+        this.behavior.maxHeight = behaviorProperties.maxHeight.value
+        this.behavior.isDraggable = behaviorProperties.isDraggable
+        this.behavior.expandedOffset = behaviorProperties.expandedOffset
+        this.behavior.halfExpandedRatio = behaviorProperties.halfExpandedRatio
+        this.behavior.isHideable = behaviorProperties.isHideable
+        this.behavior.peekHeight = behaviorProperties.peekHeight.value
+        this.behavior.isFitToContents = behaviorProperties.isFitToContents
+        this.behavior.skipCollapsed = behaviorProperties.skipCollapsed
+        this.behavior.isGestureInsetBottomIgnored = behaviorProperties.isGestureInsetBottomIgnored
+    }
+
     fun updateParameters(
         onDismissRequest: () -> Unit,
         properties: BottomSheetDialogProperties,
@@ -402,6 +514,7 @@ private class BottomSheetDialogWrapper(
         setLayoutDirection(layoutDirection)
         setCanceledOnTouchOutside(properties.dismissOnClickOutside)
         setNavigationBarProperties(properties.navigationBarProperties)
+        setBehaviorProperties(properties.behaviorProperties)
         dismissWithAnimation = properties.dismissWithAnimation
     }
 

--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -102,7 +102,7 @@ class BottomSheetDialogProperties constructor(
  */
 @Immutable
 class BottomSheetBehaviorProperties(
-    val state: BottomSheetDialogState = BottomSheetDialogState.Collapsed,
+    val state: State = State.Collapsed,
     val maxWidth: Size = Size.NotSet,
     val maxHeight: Size = Size.NotSet,
     val isDraggable: Boolean = true,
@@ -151,15 +151,13 @@ class BottomSheetBehaviorProperties(
     }
 
     @Immutable
-    enum class BottomSheetDialogState {
+    enum class State {
         @Stable
         Expanded,
         @Stable
         HalfExpanded,
         @Stable
-        Collapsed,
-        @Stable
-        Hidden
+        Collapsed
     }
 
     @JvmInline
@@ -486,10 +484,9 @@ private class BottomSheetDialogWrapper(
 
     private fun setBehaviorProperties(behaviorProperties: BottomSheetBehaviorProperties) {
         this.behavior.state = when (behaviorProperties.state) {
-            BottomSheetBehaviorProperties.BottomSheetDialogState.Expanded -> STATE_EXPANDED
-            BottomSheetBehaviorProperties.BottomSheetDialogState.Collapsed -> STATE_COLLAPSED
-            BottomSheetBehaviorProperties.BottomSheetDialogState.HalfExpanded -> STATE_HALF_EXPANDED
-            BottomSheetBehaviorProperties.BottomSheetDialogState.Hidden -> STATE_HIDDEN
+            BottomSheetBehaviorProperties.State.Expanded -> STATE_EXPANDED
+            BottomSheetBehaviorProperties.State.Collapsed -> STATE_COLLAPSED
+            BottomSheetBehaviorProperties.State.HalfExpanded -> STATE_HALF_EXPANDED
         }
         this.behavior.maxWidth = behaviorProperties.maxWidth.value
         this.behavior.maxHeight = behaviorProperties.maxHeight.value


### PR DESCRIPTION
Now, developers can set `BottomSheetBehavior` with `BottomSheetBehaviorProperties`.

See [official docs](https://developer.android.com/reference/com/google/android/material/bottomsheet/BottomSheetBehavior) for detail.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/7759511/198203640-6653dab9-ff95-4063-bbe9-12b7ccf0cd85.png">
