### PR TITLE
Unintended dark dim behind sheet

### DIFF
--- a/bottomsheetdialog-compose/src/main/res/values/styles.xml
+++ b/bottomsheetdialog-compose/src/main/res/values/styles.xml
@@ -32,5 +32,6 @@
 
     <style name="TransparentBottomSheet" parent="Widget.MaterialComponents.BottomSheet">
         <item name="backgroundTint">@android:color/transparent</item>
+        <item name="android:elevation">0dp</item>
     </style>
 </resources>


### PR DESCRIPTION
Close #10 

## Context
set BottomSheet's elevation to 0. 
Default elevation(8dp) cause unintended dark dim behind sheet.

<img width="1566" alt="스크린샷 2022-11-09 오후 10 14 09" src="https://user-images.githubusercontent.com/7759511/200840139-38564b33-ebc7-46d8-afe3-5768f51d9faf.png">

## Changes
- set BottomSheet elevation by ?attr/bottomSheetStyle

## Result
https://user-images.githubusercontent.com/7759511/200845062-fea3bfae-0258-4909-a177-91eff77c12ca.mp4


