### PR TITLE
install Dialog's OnBackPressedDispatcher

### DIFF
--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -6,6 +6,7 @@ import android.graphics.Outline
 import android.os.Build
 import android.view.*
 import androidx.activity.addCallback
+import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
 import androidx.annotation.Px
@@ -433,6 +434,7 @@ private class BottomSheetDialogWrapper(
         setContentView(bottomSheetDialogLayout)
         ViewTreeLifecycleOwner.set(bottomSheetDialogLayout, ViewTreeLifecycleOwner.get(composeView))
         ViewTreeViewModelStoreOwner.set(bottomSheetDialogLayout, ViewTreeViewModelStoreOwner.get(composeView))
+        bottomSheetDialogLayout.setViewTreeOnBackPressedDispatcherOwner(this)
         bottomSheetDialogLayout.setViewTreeSavedStateRegistryOwner(
             composeView.findViewTreeSavedStateRegistryOwner()
         )


### PR DESCRIPTION
Inside BottomSheetDialog, OnBackPressedDispatcherOwner needs to be set via ViewTreeOnBackPressedDispatcherOwner, otherwise BackHandler will dispatch event to ComponentActivity(drilling down from LocalContext).

Compose Dialog use `ComponentDialog` which provides default ViewTreeElements (`ViewTreeLifecycleOwner`, `VIewTreeSavedStateRegistryOwner`, `ViewTreeOnBackPressedDispatcherOwner`), however `AppCompatDialog` does not install any of these default ViewTreeElements, which causes unexpected difference.