### PR TITLE
fix nestedScroll when Content is not scrollable

### DIFF
--- a/bottomsheetdialog-compose/build.gradle
+++ b/bottomsheetdialog-compose/build.gradle
@@ -52,6 +52,7 @@ android {
 dependencies {
     implementation platform(Dependencies.composeBom)
     implementation Dependencies.composeUI
+    implementation Dependencies.composeFoundation
     implementation Dependencies.androidxActivityKtx
     implementation Dependencies.androidxCoreKtx
     implementation Dependencies.material

--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -1,5 +1,8 @@
 package com.holix.android.bottomsheetdialog.compose
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Outline
@@ -279,6 +282,7 @@ fun BottomSheetDialog(
                 BottomSheetDialogLayout(
                     Modifier
                         .nestedScroll(rememberNestedScrollInteropConnection())
+                        .scrollable(state = rememberScrollableState{ 0f }, orientation = Orientation.Vertical)
                         .semantics { dialog() },
                 ) {
                     currentContent()


### PR DESCRIPTION
using `rememberNestedScrollInteropConnection` is not enough for `bottomSheetBehavior`.
If `compose` contains non scrollable content than ComposeView will consume all the input event without dispatching it to the `CoordinatorLayout`.

Because in that case, there is no `Scrollable` Modifier to handle nestedScroll. 
This PR attach empty `Scrollable` Modifier at the root of Content so the `NestedScrollInteropConnection` can handle the scroll event even when the actual content is not scrollable.