### PR TITLE
Remove unnecessary code

### DIFF
--- a/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
+++ b/bottomsheetdialog-compose/src/main/kotlin/com/holix/android/bottomsheetdialog/compose/BottomSheetDialog.kt
@@ -382,7 +382,6 @@ private class BottomSheetDialogWrapper(
 
     init {
         val window = window ?: error("Dialog has no window")
-        window.requestFeature(Window.FEATURE_NO_TITLE)
         window.setBackgroundDrawableResource(android.R.color.transparent)
         bottomSheetDialogLayout = BottomSheetDialogLayout(context, window).apply {
             // Set unique id for AbstractComposeView. This allows state restoration for the state


### PR DESCRIPTION
Close #23

Since we're using NoActionBar theme for the Dialog, there's no need to set FEATURE_NO_TITLE.